### PR TITLE
Custom user css

### DIFF
--- a/install.php
+++ b/install.php
@@ -8,6 +8,14 @@ if (!defined("GLPI_MOD_DIR")) {
 
 //without plugin
 if(!is_file(GLPI_ROOT.'/index.php.bak')) {
+	//Create editable basepath, if missing.
+	if ( ! file_exists(GLPI_MOD_FILES_DIR)) {
+	   mkdir(GLPI_MOD_FILES_DIR);
+	}
+
+	if( ! file_exists(GLPI_MOD_USER_CSS_PATH)) {
+	   file_put_contents(GLPI_MOD_USER_CSS_PATH, '/* Write custom CSS for login page here */');
+	}
 	
 	rename(GLPI_ROOT.'/index.php', GLPI_ROOT.'/index.php.bak');
 	copy(GLPI_MOD_DIR.'/src/index.php', GLPI_ROOT.'/index.php');

--- a/install.php
+++ b/install.php
@@ -13,8 +13,8 @@ if(!is_file(GLPI_ROOT.'/index.php.bak')) {
 	   mkdir(GLPI_MOD_FILES_DIR);
 	}
 
-	if( ! file_exists(GLPI_MOD_USER_CSS_PATH)) {
-	   file_put_contents(GLPI_MOD_USER_CSS_PATH, '/* Write custom CSS for login page here */');
+	if( ! file_exists(GLPI_MOD_CUSTOM_LOGIN_CSS_PATH)) {
+	   file_put_contents(GLPI_MOD_CUSTOM_LOGIN_CSS_PATH, '/* Write custom CSS for login page here */');
 	}
 	
 	rename(GLPI_ROOT.'/index.php', GLPI_ROOT.'/index.php.bak');

--- a/setup.php
+++ b/setup.php
@@ -4,8 +4,8 @@ if (!defined("GLPI_MOD_FILES_DIR")) {
    define("GLPI_MOD_FILES_DIR", GLPI_ROOT."/files/_plugins/mod");
 }
 
-if (!defined("GLPI_MOD_USER_CSS_PATH")) {
-   define("GLPI_MOD_USER_CSS_PATH", GLPI_MOD_FILES_DIR.'/userstyles.css');
+if (!defined("GLPI_MOD_CUSTOM_LOGIN_CSS_PATH")) {
+   define("GLPI_MOD_CUSTOM_LOGIN_CSS_PATH", GLPI_MOD_FILES_DIR.'/loginstyles.css');
 }
 
 function plugin_init_mod() {

--- a/setup.php
+++ b/setup.php
@@ -1,5 +1,13 @@
 <?php
 
+if (!defined("GLPI_MOD_FILES_DIR")) {
+   define("GLPI_MOD_FILES_DIR", GLPI_ROOT."/files/_plugins/mod");
+}
+
+if (!defined("GLPI_MOD_USER_CSS_PATH")) {
+   define("GLPI_MOD_USER_CSS_PATH", GLPI_MOD_FILES_DIR.'/userstyles.css');
+}
+
 function plugin_init_mod() {
   
    global $PLUGIN_HOOKS, $LANG ;
@@ -17,7 +25,17 @@ function plugin_init_mod() {
 	   //$PLUGIN_HOOKS['add_javascript']['mod'] = "scripts/mod.js";
 	   $PLUGIN_HOOKS['add_javascript']['mod'][] = "scripts/stats.js";
 	   $PLUGIN_HOOKS['add_javascript']['mod'][] = "scripts/ind.js";
- 	}                    
+ 	}
+
+        //Create editable basepath, if missing.
+        if ( ! is_writable(GLPI_MOD_FILES_DIR)) {
+           mkdir(GLPI_MOD_FILES_DIR);
+        }
+
+        //Add user customizable file if missing
+        if( ! file_exists(GLPI_MOD_USER_CSS_PATH)) {
+           file_put_contents(GLPI_MOD_USER_CSS_PATH, '/* Write custom login CSS after this */');
+        }
 }
 
 

--- a/setup.php
+++ b/setup.php
@@ -25,16 +25,7 @@ function plugin_init_mod() {
 	   //$PLUGIN_HOOKS['add_javascript']['mod'] = "scripts/mod.js";
 	   $PLUGIN_HOOKS['add_javascript']['mod'][] = "scripts/stats.js";
 	   $PLUGIN_HOOKS['add_javascript']['mod'][] = "scripts/ind.js";
-           //Create editable basepath, if missing.
-           if ( ! is_writable(GLPI_MOD_FILES_DIR)) {
-              mkdir(GLPI_MOD_FILES_DIR);
-           }
-
-           //Add user customizable file if missing
-           if( ! file_exists(GLPI_MOD_USER_CSS_PATH)) {
-              file_put_contents(GLPI_MOD_USER_CSS_PATH, '/* Write custom login CSS after this */');
-           }
- 	}
+   }
 }
 
 

--- a/setup.php
+++ b/setup.php
@@ -25,17 +25,16 @@ function plugin_init_mod() {
 	   //$PLUGIN_HOOKS['add_javascript']['mod'] = "scripts/mod.js";
 	   $PLUGIN_HOOKS['add_javascript']['mod'][] = "scripts/stats.js";
 	   $PLUGIN_HOOKS['add_javascript']['mod'][] = "scripts/ind.js";
+           //Create editable basepath, if missing.
+           if ( ! is_writable(GLPI_MOD_FILES_DIR)) {
+              mkdir(GLPI_MOD_FILES_DIR);
+           }
+
+           //Add user customizable file if missing
+           if( ! file_exists(GLPI_MOD_USER_CSS_PATH)) {
+              file_put_contents(GLPI_MOD_USER_CSS_PATH, '/* Write custom login CSS after this */');
+           }
  	}
-
-        //Create editable basepath, if missing.
-        if ( ! is_writable(GLPI_MOD_FILES_DIR)) {
-           mkdir(GLPI_MOD_FILES_DIR);
-        }
-
-        //Add user customizable file if missing
-        if( ! file_exists(GLPI_MOD_USER_CSS_PATH)) {
-           file_put_contents(GLPI_MOD_USER_CSS_PATH, '/* Write custom login CSS after this */');
-        }
 }
 
 

--- a/src/index.php
+++ b/src/index.php
@@ -133,6 +133,11 @@ if (!file_exists(GLPI_CONFIG_DIR . "/config_db.php")) {
 			background: url(cloud.png) no-repeat;		
 			background-size: cover; 		
 		}
+
+<?php
+echo file_get_contents(GLPI_MOD_USER_CSS_PATH);
+?>
+
 	</style>      
     
 </head>

--- a/src/index.php
+++ b/src/index.php
@@ -135,7 +135,7 @@ if (!file_exists(GLPI_CONFIG_DIR . "/config_db.php")) {
 		}
 
 <?php
-echo file_get_contents(GLPI_MOD_USER_CSS_PATH);
+echo file_get_contents(GLPI_MOD_CUSTOM_LOGIN_CSS_PATH);
 ?>
 
 	</style>      


### PR DESCRIPTION
Allow users to add custom CSS on GLPI login page through plugin glpi-modifications.

When installing the plugin, a CSS file is created in /files/_plugins where the user can specify custom CSS for the login page. The login page template provided by this plugin now includes an instruction to fetch this custom CSS and inline it into the page header.

Related to ticket https://github.com/stdonato/glpi-modifications/issues/14